### PR TITLE
Release v1.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,14 @@
-name: Release Candidate
+name: Release
 
 on:
-  push:
-    tags:
-      - '*-rc*'
-      - 'v*rc*'
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
 jobs:
-  build-and-release:
+  build-and-upload:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -21,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install Node dependencies (if any)
         run: |
@@ -38,7 +36,7 @@ jobs:
       - name: Setup PHP + Composer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: "8.1"
           tools: composer
 
       - name: Install Composer dependencies (if any)
@@ -50,26 +48,20 @@ jobs:
       - name: Prepare ZIP artifact
         id: make_zip
         run: |
-          TAG="${{ github.ref_name }}"
+          TAG="${{ github.event.release.tag_name }}"
           OUTDIR=release
           mkdir -p "$OUTDIR"
-          ZIPFILE="$OUTDIR/${TAG}.zip"
+          ZIPFILE="$OUTDIR/payload-woocommerce.zip"
 
-          # Zip the full project (including vendor, build, etc.)
-          # Exclude git metadata, GitHub workflows, and the release folder itself
           zip -r "$ZIPFILE" . \
-            -x ".git/*" ".github/*" "release/*" "node_modules/*" 
+            -x ".git/*" ".github/*" "release/*" "node_modules/*"
 
           echo "zip_path=$ZIPFILE" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release + upload ZIP
-        uses: softprops/action-gh-release@v2
+      - name: Upload ZIP to release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          generate_release_notes: true
-          prerelease: true
-          draft: false
-          files: ${{ steps.make_zip.outputs.zip_path }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ steps.make_zip.outputs.zip_path }}" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Prepare ZIP artifact
         id: make_zip
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           OUTDIR=release
           mkdir -p "$OUTDIR"
           ZIPFILE="$OUTDIR/payload-woocommerce.zip"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,18 @@
 == Changelog ==
 
+= v1.4.1 =
+
+* Truncate API-key in settings
+* Improved error handling during form initialization
+
+= v1.4.0 =
+
+* Email-based customer lookup
+* Customer data syncing
+* Added company field support
+* Auto-complete virtual orders
+* Improved validation and error handling
+
 = v1.3.0 =
 
 * Fixed customer ID handling in get_payload_customer_id() 

--- a/includes/class-wc-payload-gateway.php
+++ b/includes/class-wc-payload-gateway.php
@@ -78,10 +78,88 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 			),
 			'api_key' => array(
 				'title' => __( 'API Key', 'payload' ),
-				'type'  => 'password',
-				'label' => __( 'API Key', 'payload' ),
+				'type'  => 'secret',
 			),
 		);
+	}
+
+	/**
+	 * Render a write-only secret field. The saved value is never sent to the browser.
+	 *
+	 * @since  1.5.0
+	 * @param  string $key  Field key.
+	 * @param  array  $data Field data.
+	 * @return string HTML output.
+	 */
+	public function generate_secret_html( $key, $data ) {
+		$field_key = $this->get_field_key( $key );
+		$defaults  = array(
+			'title'       => '',
+			'class'       => '',
+			'css'         => '',
+			'placeholder' => '',
+			'desc_tip'    => false,
+			'description' => '',
+		);
+		$data      = wp_parse_args( $data, $defaults );
+
+		$saved_value = $this->get_option( $key );
+		$has_value   = (bool) $saved_value;
+		$description = $has_value
+			? __( 'An API key is saved. Enter a new value to replace it.', 'payload' )
+			: $data['description'];
+		$placeholder = $has_value
+			? '••••••••' . substr( $saved_value, -6 )
+			: $data['placeholder'];
+
+		ob_start();
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field_key ); ?>">
+					<?php echo wp_kses_post( $data['title'] ); ?>
+				</label>
+			</th>
+			<td class="forminp">
+				<fieldset>
+					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+					<input
+						class="input-text regular-input <?php echo esc_attr( $data['class'] ); ?>"
+						type="password"
+						name="<?php echo esc_attr( $field_key ); ?>"
+						id="<?php echo esc_attr( $field_key ); ?>"
+						style="<?php echo esc_attr( $data['css'] ); ?>"
+						value=""
+						placeholder="<?php echo esc_attr( $placeholder ); ?>"
+						autocomplete="new-password"
+					/>
+					<?php if ( ! empty( $description ) ) : ?>
+						<p class="description"><?php echo wp_kses_post( $description ); ?></p>
+					<?php endif; ?>
+				</fieldset>
+			</td>
+		</tr>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Validate the secret field. Keeps the existing value if the field is left empty.
+	 *
+	 * @since  1.5.0
+	 * @param  string $key   Field key.
+	 * @param  string $value Posted value.
+	 * @return string Validated value.
+	 */
+	public function validate_secret_field( $key, $value ) {
+		$value = is_null( $value ) ? '' : trim( $value );
+
+		if ( '' === $value ) {
+			return $this->get_option( $key );
+		}
+
+		return sanitize_text_field( $value );
 	}
 
 	/**

--- a/includes/payload-api-functions.php
+++ b/includes/payload-api-functions.php
@@ -74,6 +74,17 @@ function get_intent( $data ) {
 		);
 
 		return array( 'client_token' => $clientToken->id );
+	} catch ( Payload\Exceptions\Unauthorized $e ) {
+		$logger = wc_get_logger();
+		$logger->error(
+			'Failed to create Payload client token: ' . $e->getMessage(),
+			array( 'source' => 'payload-woocommerce' )
+		);
+		return new WP_Error(
+			'payload_token_error',
+			__( 'Unable to initialize payment form: Invalid API Key.', 'payload' ),
+			array( 'status' => 400 )
+		);
 	} catch ( Exception $e ) {
 		$logger = wc_get_logger();
 		$logger->error(
@@ -101,10 +112,9 @@ function payload_register_rest_api_routes() {
 		'wc/v3',
 		'payload_client_token',
 		array(
-			'methods'             => 'GET',
-			'callback'            => 'get_intent',
+			'methods'  => 'GET',
+			'callback' => 'get_intent',
 		)
 	);
 }
 add_action( 'rest_api_init', 'payload_register_rest_api_routes' );
-

--- a/package.json
+++ b/package.json
@@ -1,54 +1,55 @@
 {
-    "name": "payload-woocommerce",
-    "version": "1.3.0",
-    "description": "",
-    "author": "",
-    "license": "GPL-2.0-or-later",
-    "keywords": [
-        "wordpress",
-        "woocommerce",
-        "payload",
-        "payments",
-        "plugin"
-    ],
-    "homepage": "https://github.com/payload-code/payload-woocommerce",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/payload-code/payload-woocommerce.git"
-    },
-    "bugs": {
-        "url": "https://github.com/payload-code/payload-woocommerce/issues"
-    },
-    "main": "build/index.js",
-    "dependencies": {
-        "payload-react": "^1.2.6",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-    },
-    "devDependencies": {
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "@babel/preset-env": "^7.26.7",
-        "@babel/preset-react": "^7.26.3",
-        "@woocommerce/eslint-plugin": "^2.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/scripts": "^30.9.0"
-    },
-    "scripts": {
-        "build": "wp-scripts build",
-        "check-engines": "wp-scripts check-engines",
-        "check-licenses": "wp-scripts check-licenses",
-        "format": "wp-scripts format",
-        "lint": "npm run lint:css && npm run lint:js && npm run lint:pkg-json && npm run lint:md::docs",
-        "lint:css": "wp-scripts lint-style",
-        "lint:js": "wp-scripts lint-js",
-        "lint:md::docs": "wp-scripts lint-md-docs",
-        "lint:pkg-json": "wp-scripts lint-pkg-json",
-        "packages-update": "wp-scripts packages-update",
-        "start": "wp-scripts start",
-        "test:e2e": "wp-scripts test-e2e",
-        "test:unit": "wp-scripts test-unit-js",
-        "test:php": "composer test",
-        "test:all": "npm run test:php"
-    }
+  "name": "payload-woocommerce",
+  "version": "1.4.1",
+  "description": "",
+  "author": "",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "wordpress",
+    "woocommerce",
+    "payload",
+    "payments",
+    "plugin"
+  ],
+  "homepage": "https://github.com/payload-code/payload-woocommerce",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/payload-code/payload-woocommerce.git"
+  },
+  "bugs": {
+    "url": "https://github.com/payload-code/payload-woocommerce/issues"
+  },
+  "main": "build/index.js",
+  "dependencies": {
+    "payload-react": "^1.2.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.25.9",
+    "@babel/preset-env": "^7.26.7",
+    "@babel/preset-react": "^7.26.3",
+    "@woocommerce/eslint-plugin": "^2.3.0",
+    "@wordpress/html-entities": "^4.3.0",
+    "@wordpress/i18n": "^5.3.0",
+    "@wordpress/scripts": "^30.9.0"
+  },
+  "scripts": {
+    "build": "wp-scripts build",
+    "check-engines": "wp-scripts check-engines",
+    "check-licenses": "wp-scripts check-licenses",
+    "format": "wp-scripts format",
+    "lint": "npm run lint:css && npm run lint:js && npm run lint:pkg-json && npm run lint:md::docs",
+    "lint:css": "wp-scripts lint-style",
+    "lint:js": "wp-scripts lint-js",
+    "lint:md::docs": "wp-scripts lint-md-docs",
+    "lint:pkg-json": "wp-scripts lint-pkg-json",
+    "packages-update": "wp-scripts packages-update",
+    "start": "wp-scripts start",
+    "test:e2e": "wp-scripts test-e2e",
+    "test:unit": "wp-scripts test-unit-js",
+    "test:php": "composer test",
+    "test:all": "npm run test:php"
+  }
 }
+

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,19 @@ https://support.payload.com
 
 == Changelog ==
 
+= v1.4.1 =
+
+* Truncate API-key in settings
+* Improved error handling during form initialization
+
+= v1.4.0 =
+
+* Email-based customer lookup
+* Customer data syncing
+* Added company field support
+* Auto-complete virtual orders
+* Improved validation and error handling
+
 = v1.3.0 =
 
 * Fixed customer ID handling in get_payload_customer_id() 

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -9,7 +9,7 @@ import {
 } from 'payload-react';
 
 import '../css/style.scss';
-/* global MutationObserver */
+/* global MutationObserver, Node */
 
 const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
 const { getSetting } = window.wc.wcSettings;

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -65,13 +65,16 @@ const Content = ( props ) => {
 	const { eventRegistration, emitResponse, billing } = props;
 	const { onPaymentSetup } = eventRegistration;
 	const [ clientToken, setClientToken ] = useState();
+	const [ fetchError, setFetchError ] = useState();
 	const paymentFormRef = useRef( null );
 	const hasSubscription = !! props.cartData.extensions?.subscriptions?.length;
 
 	useEffect( () => {
-		wp.apiFetch( { path: 'wc/v3/payload_client_token' } ).then( ( data ) =>
-			setClientToken( data.client_token )
-		);
+		wp.apiFetch( { path: 'wc/v3/payload_client_token' } )
+			.then( ( data ) => setClientToken( data.client_token ) )
+			.catch( ( err ) => {
+				setFetchError( err?.message || 'Unable to load payment form.' );
+			} );
 
 		const unsubscribe = onPaymentSetup( async () => {
 			try {
@@ -106,6 +109,10 @@ const Content = ( props ) => {
 		emitResponse.responseTypes.SUCCESS,
 		onPaymentSetup,
 	] );
+
+	if ( fetchError ) {
+		return <div className="pl-form-error">{ fetchError }</div>;
+	}
 
 	if ( ! clientToken ) {
 		return;
@@ -148,7 +155,13 @@ const AddPaymentMethod = () => {
 	useEffect( () => {
 		wp.apiFetch( {
 			path: 'wc/v3/payload_client_token?type=payment_method',
-		} ).then( ( data ) => setClientToken( data.client_token ) );
+		} )
+			.then( ( data ) => setClientToken( data.client_token ) )
+			.catch( ( err ) => {
+				setGeneralErrorMessage(
+					err?.message || 'Unable to load payment form.'
+				);
+			} );
 
 		const form = getForm();
 		const submitBtn = document.getElementById( 'place_order' );
@@ -192,6 +205,9 @@ const AddPaymentMethod = () => {
 	}, [ paymentMethodId ] );
 
 	if ( ! clientToken ) {
+		if ( generalErrorMessage ) {
+			return <div className="pl-form-error">{ generalErrorMessage }</div>;
+		}
 		return;
 	}
 
@@ -252,25 +268,15 @@ const BlockGateway = {
 
 registerPaymentMethod( BlockGateway );
 
-const mountPaymentMethodForm = () => {
-	if ( document.querySelector( '#payload-add-payment-method' ) ) {
-		const domContainer = document.querySelector(
-			'#payload-add-payment-method'
-		);
-
-		const root = ReactDOM.createRoot( domContainer );
-		root.render( <AddPaymentMethod /> );
-	}
-};
-
 // Expose a single global that mounts the payment form ONCE (handles lazy / re-renders)
+// IMPORTANT: This must remain an IIFE so that mountedContainer, currentRoot, and observer
+// are shared across calls. Converting to a plain function would reset state on every invocation.
 window.plMountPaymentMethodForm = ( () => {
-	const TARGET_SELECTOR = '#payload-add-payment-method';
+	const TARGET_ID = 'payload-add-payment-method';
 
 	let mountedContainer = null; // track which exact element we mounted into
+	let currentRoot = null; // track the React root so we can unmount on re-renders
 	let observer = null;
-
-	// --- helpers -------------------------------------------------------------
 
 	const actuallyMount = ( container ) => {
 		if ( ! container ) {
@@ -285,10 +291,14 @@ window.plMountPaymentMethodForm = ( () => {
 			return;
 		}
 
-		// If your function can take a container, pass it in:
-		// mountPaymentMethodForm(container);
-		mountPaymentMethodForm();
+		// Unmount the previous React root to clean up subscriptions and state.
+		if ( currentRoot ) {
+			currentRoot.unmount();
+			currentRoot = null;
+		}
 
+		currentRoot = ReactDOM.createRoot( container );
+		currentRoot.render( <AddPaymentMethod /> );
 		mountedContainer = container;
 	};
 
@@ -299,9 +309,8 @@ window.plMountPaymentMethodForm = ( () => {
 	};
 
 	const onLoad = () => {
-		const container = document.querySelector( TARGET_SELECTOR );
+		const container = document.getElementById( TARGET_ID );
 
-		// If we have a container, mount now.
 		if ( container ) {
 			actuallyMount( container );
 			cleanup();
@@ -325,11 +334,17 @@ window.plMountPaymentMethodForm = ( () => {
 			return;
 		}
 
-		observer = new MutationObserver( () => {
-			// On any DOM change, see if our container exists and handle it
-			const container = document.querySelector( TARGET_SELECTOR );
-			if ( container ) {
-				handleFound( container );
+		observer = new MutationObserver( ( mutations ) => {
+			for ( const mutation of mutations ) {
+				for ( const node of mutation.addedNodes ) {
+					if (
+						node.nodeType === Node.ELEMENT_NODE &&
+						node.id === TARGET_ID
+					) {
+						handleFound( node );
+						return;
+					}
+				}
 			}
 		} );
 
@@ -340,8 +355,7 @@ window.plMountPaymentMethodForm = ( () => {
 	};
 
 	const init = () => {
-		// First, if the container already exists, handle it
-		const container = document.querySelector( TARGET_SELECTOR );
+		const container = document.getElementById( TARGET_ID );
 		if ( container ) {
 			handleFound( container );
 		}

--- a/tests/Unit/API/PayloadAPIFunctions_Test.php
+++ b/tests/Unit/API/PayloadAPIFunctions_Test.php
@@ -83,5 +83,4 @@ class PayloadAPIFunctions_Test extends UnitTestCase {
 
 		$this->assertTrue( true );
 	}
-
 }

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -30,7 +30,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$this->assertArrayHasKey( 'enabled', $this->gateway->form_fields );
 		$this->assertArrayHasKey( 'api_key', $this->gateway->form_fields );
 		$this->assertEquals( 'checkbox', $this->gateway->form_fields['enabled']['type'] );
-		$this->assertEquals( 'password', $this->gateway->form_fields['api_key']['type'] );
+		$this->assertEquals( 'secret', $this->gateway->form_fields['api_key']['type'] );
 	}
 
 	public function test_payment_scripts_skips_admin() {

--- a/tests/mocks/payload-mocks.php
+++ b/tests/mocks/payload-mocks.php
@@ -43,7 +43,6 @@ namespace Payload {
 		public $payment_method;
 		public $status;
 
-
 		public static function get( $id ) {
 			$mock                    = new self();
 			$mock->id                = $id;

--- a/tests/mocks/woocommerce-mocks.php
+++ b/tests/mocks/woocommerce-mocks.php
@@ -25,6 +25,12 @@ class WC_Payment_Gateway {
 	public function is_available() {
 		return true;
 	}
+	public function get_option( $key, $default = '' ) {
+		return $this->settings[ $key ] ?? $default;
+	}
+	public function get_field_key( $key ) {
+		return 'woocommerce_' . $this->id . '_' . $key;
+	}
 	public function get_return_url( $order ) {
 		return 'http://example.com/thank-you/';
 	}


### PR DESCRIPTION
# Description

Security and reliability improvements for the payment gateway admin settings and checkout payment form initialization, along with CI workflow updates.

Changes include:

- [x] Write-only API key field — API key is never sent to the browser; admin sees a masked placeholder with the last 6 characters and a message indicating a key is saved
- [x] Error handling for `apiFetch` — both checkout and add-payment-method flows now catch and display errors when the client token request fails
- [x] Unauthorized API key handling — `get_intent` returns a descriptive `WP_Error` on `Payload\Exceptions\Unauthorized`, surfacing "Invalid API Key" to the frontend
- [x] `plMountPaymentMethodForm` cleanup — restored IIFE pattern (prevents state reset on repeated calls), unmounts previous React root on re-renders, passes container directly instead of re-querying the DOM, and scopes MutationObserver to only check added nodes by ID
- [x] Release workflow — triggers on `release: published` instead of RC tags, builds and uploads zip to the existing GitHub release via `gh release upload`

## Type of change

- Enhancement (non-breaking change which enhances functionality)