### PR TITLE
Tokenize payment method for non-guest checkouts

### DIFF
--- a/includes/class-wc-payload-gateway.php
+++ b/includes/class-wc-payload-gateway.php
@@ -504,8 +504,11 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 			$this->associate_customer_with_payment( $payment, $user_id_from_order );
 		}
 
-		// Create and set token if subscription
-		if ( class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Order::order_contains_subscription( $order->get_id() ) ) {
+		// Create and set token if subscription, or if the payment method should be kept active for a known user
+		$has_subscription = class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Order::order_contains_subscription( $order->get_id() );
+		$should_tokenize  = $has_subscription || ( ! empty( $payment->payment_method['keep_active'] ) && $user_id_from_order );
+
+		if ( $should_tokenize ) {
 			$token = $this->create_token( $payment->payment_method, $user_id_from_order );
 			$this->update_order_payment_method_token( $order, $token );
 		} else {

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -68,6 +68,7 @@ const Content = ( props ) => {
 	const [ fetchError, setFetchError ] = useState();
 	const paymentFormRef = useRef( null );
 	const hasSubscription = !! props.cartData.extensions?.subscriptions?.length;
+	const isGuest = ! wp.data.select( 'wc/store/checkout' )?.getCustomerId();
 
 	useEffect( () => {
 		wp.apiFetch( { path: 'wc/v3/payload_client_token' } )
@@ -129,7 +130,7 @@ const Content = ( props ) => {
 				payment={ {
 					amount: billing.cartTotal.value / 100,
 					payment_method: {
-						keep_active: hasSubscription,
+						keep_active: hasSubscription || ! isGuest,
 					},
 				} }
 			>

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -16,6 +16,11 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$this->gateway = new WC_Payload_Gateway();
 	}
 
+	protected function tearDown(): void {
+		\Payload\Transaction::$payment_method_override = null;
+		parent::tearDown();
+	}
+
 	public function test_constructor_sets_correct_properties() {
 		$this->assertEquals( 'payload', $this->gateway->id );
 		$this->assertTrue( $this->gateway->has_fields );
@@ -436,8 +441,6 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 1 );
 
 		$this->assertEquals( 'processed', $result->status );
-
-		\Payload\Transaction::$payment_method_override = null;
 	}
 
 	public function test_process_client_side_payment_does_not_tokenize_for_guest_even_when_keep_active() {
@@ -477,8 +480,6 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 0 );
 
 		$this->assertEquals( 'processed', $result->status );
-
-		\Payload\Transaction::$payment_method_override = null;
 	}
 
 	public function test_process_client_side_payment_does_not_tokenize_when_keep_active_false() {
@@ -518,8 +519,6 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 1 );
 
 		$this->assertEquals( 'processed', $result->status );
-
-		\Payload\Transaction::$payment_method_override = null;
 	}
 
 	public function test_associate_customer_with_payment_success() {

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -394,6 +394,134 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$this->assertEquals( 'processed', $result->status );
 	}
 
+	public function test_process_client_side_payment_tokenizes_when_keep_active_and_user_id() {
+		\Payload\Transaction::$payment_method_override = array(
+			'id'          => 'pm_123',
+			'description' => 'Visa ending in 1111',
+			'keep_active' => true,
+			'card'        => array(
+				'card_brand'  => 'visa',
+				'card_number' => '4111111111111111',
+				'expiry'      => '12/2025',
+			),
+		);
+
+		$order_mock = Mockery::mock( 'WC_Order' );
+		$order_mock->shouldReceive( 'get_id' )->andReturn( 123 );
+		$order_mock->shouldReceive( 'get_total' )->andReturn( 100.00 );
+
+		$subscription_order_mock = Mockery::mock( 'alias:WC_Subscriptions_Order' );
+		$subscription_order_mock->shouldReceive( 'order_contains_subscription' )
+			->with( 123 )
+			->andReturn( false );
+
+		$token_mock = Mockery::mock( 'WC_Payment_Token_CC' );
+
+		$gateway = Mockery::mock( 'WC_Payload_Gateway' )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+		$gateway->shouldReceive( 'create_token' )
+			->once()
+			->with( Mockery::type( 'array' ), 1 )
+			->andReturn( $token_mock );
+		$gateway->shouldReceive( 'update_order_payment_method_token' )
+			->once()
+			->with( $order_mock, $token_mock );
+		$gateway->shouldNotReceive( 'update_order_payment_method' );
+
+		$reflection = new ReflectionClass( 'WC_Payload_Gateway' );
+		$method     = $reflection->getMethod( 'process_client_side_payment' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 1 );
+
+		$this->assertEquals( 'processed', $result->status );
+
+		\Payload\Transaction::$payment_method_override = null;
+	}
+
+	public function test_process_client_side_payment_does_not_tokenize_for_guest_even_when_keep_active() {
+		\Payload\Transaction::$payment_method_override = array(
+			'id'          => 'pm_123',
+			'description' => 'Visa ending in 1111',
+			'keep_active' => true,
+			'card'        => array(
+				'card_brand'  => 'visa',
+				'card_number' => '4111111111111111',
+				'expiry'      => '12/2025',
+			),
+		);
+
+		$order_mock = Mockery::mock( 'WC_Order' );
+		$order_mock->shouldReceive( 'get_id' )->andReturn( 123 );
+		$order_mock->shouldReceive( 'get_total' )->andReturn( 100.00 );
+
+		$subscription_order_mock = Mockery::mock( 'alias:WC_Subscriptions_Order' );
+		$subscription_order_mock->shouldReceive( 'order_contains_subscription' )
+			->with( 123 )
+			->andReturn( false );
+
+		$gateway = Mockery::mock( 'WC_Payload_Gateway' )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+		$gateway->shouldNotReceive( 'create_token' );
+		$gateway->shouldNotReceive( 'update_order_payment_method_token' );
+		$gateway->shouldReceive( 'update_order_payment_method' )
+			->once()
+			->with( $order_mock, 'Visa ending in 1111', 'pm_123' );
+
+		$reflection = new ReflectionClass( 'WC_Payload_Gateway' );
+		$method     = $reflection->getMethod( 'process_client_side_payment' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 0 );
+
+		$this->assertEquals( 'processed', $result->status );
+
+		\Payload\Transaction::$payment_method_override = null;
+	}
+
+	public function test_process_client_side_payment_does_not_tokenize_when_keep_active_false() {
+		\Payload\Transaction::$payment_method_override = array(
+			'id'          => 'pm_123',
+			'description' => 'Visa ending in 1111',
+			'keep_active' => false,
+			'card'        => array(
+				'card_brand'  => 'visa',
+				'card_number' => '4111111111111111',
+				'expiry'      => '12/2025',
+			),
+		);
+
+		$order_mock = Mockery::mock( 'WC_Order' );
+		$order_mock->shouldReceive( 'get_id' )->andReturn( 123 );
+		$order_mock->shouldReceive( 'get_total' )->andReturn( 100.00 );
+
+		$subscription_order_mock = Mockery::mock( 'alias:WC_Subscriptions_Order' );
+		$subscription_order_mock->shouldReceive( 'order_contains_subscription' )
+			->with( 123 )
+			->andReturn( false );
+
+		$gateway = Mockery::mock( 'WC_Payload_Gateway' )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+		$gateway->shouldNotReceive( 'create_token' );
+		$gateway->shouldNotReceive( 'update_order_payment_method_token' );
+		$gateway->shouldReceive( 'update_order_payment_method' )
+			->once()
+			->with( $order_mock, 'Visa ending in 1111', 'pm_123' );
+
+		$reflection = new ReflectionClass( 'WC_Payload_Gateway' );
+		$method     = $reflection->getMethod( 'process_client_side_payment' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $gateway, 'txn_123', $order_mock, 1 );
+
+		$this->assertEquals( 'processed', $result->status );
+
+		\Payload\Transaction::$payment_method_override = null;
+	}
+
 	public function test_associate_customer_with_payment_success() {
 		$payment_mock                    = Mockery::mock();
 		$payment_mock->customer_id       = null;

--- a/tests/mocks/payload-mocks.php
+++ b/tests/mocks/payload-mocks.php
@@ -43,6 +43,9 @@ namespace Payload {
 		public $payment_method;
 		public $status;
 
+		// Tests may set this to override the payment_method array returned by ::get()
+		public static $payment_method_override = null;
+
 		public static function get( $id ) {
 			$mock                    = new self();
 			$mock->id                = $id;
@@ -50,7 +53,7 @@ namespace Payload {
 			$mock->ref_number        = 'REF123';
 			$mock->customer_id       = 'cust_existing';
 			$mock->payment_method_id = 'pm_123';
-			$mock->payment_method    = array(
+			$mock->payment_method    = self::$payment_method_override ?? array(
 				'id'          => 'pm_123',
 				'description' => 'Visa ending in 1111',
 				'card'        => array(


### PR DESCRIPTION
# Description

PL-520: When a logged-in (non-guest) customer completes checkout, save the payment method as a token on their account so it can be reused — previously this only happened when the order contained a subscription.

Changes include:

- [x] Set `keep_active: true` on the client-side payment when the checkout is not a guest checkout (src/js/index.jsx)
- [x] In `process_client_side_payment`, create and attach a token when `payment_method.keep_active` is true and the order has a user, regardless of subscription (includes/class-wc-payload-gateway.php)
- [x] Add unit tests covering the three new branch combinations (keep_active + user, keep_active + guest, keep_active false)

## Type of change

- Enhancement (non-breaking change which enhances functionality)