### PR TITLE
Guard onPaymentSetup callback to only run when Payload is the active payment method

### DIFF
--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -64,7 +64,8 @@ const PaymentMethodFields = () => {
 };
 
 const Content = ( props ) => {
-	const { eventRegistration, emitResponse, billing, activePaymentMethod } = props;
+	const { eventRegistration, emitResponse, billing, activePaymentMethod } =
+		props;
 	const { onPaymentSetup } = eventRegistration;
 	const [ clientToken, setClientToken ] = useState();
 	const [ fetchError, setFetchError ] = useState();

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -16,7 +16,7 @@ const { getSetting } = window.wc.wcSettings;
 
 const PAYMENT_METHOD_NAME = 'payload';
 
-const settings = getSetting( 'payload', {} );
+const settings = getSetting( PAYMENT_METHOD_NAME, {} );
 const label =
 	decodeEntities( settings.title ) ||
 	window.wp.i18n.__( 'Credit/Debit Card', 'payload' );

--- a/src/js/index.jsx
+++ b/src/js/index.jsx
@@ -14,6 +14,8 @@ import '../css/style.scss';
 const { registerPaymentMethod } = window.wc.wcBlocksRegistry;
 const { getSetting } = window.wc.wcSettings;
 
+const PAYMENT_METHOD_NAME = 'payload';
+
 const settings = getSetting( 'payload', {} );
 const label =
 	decodeEntities( settings.title ) ||
@@ -62,7 +64,7 @@ const PaymentMethodFields = () => {
 };
 
 const Content = ( props ) => {
-	const { eventRegistration, emitResponse, billing } = props;
+	const { eventRegistration, emitResponse, billing, activePaymentMethod } = props;
 	const { onPaymentSetup } = eventRegistration;
 	const [ clientToken, setClientToken ] = useState();
 	const [ fetchError, setFetchError ] = useState();
@@ -77,6 +79,10 @@ const Content = ( props ) => {
 			} );
 
 		const unsubscribe = onPaymentSetup( async () => {
+			if ( activePaymentMethod !== PAYMENT_METHOD_NAME ) {
+				return;
+			}
+
 			try {
 				const result = await paymentFormRef.current.submit();
 				return {
@@ -108,6 +114,7 @@ const Content = ( props ) => {
 		emitResponse.responseTypes.ERROR,
 		emitResponse.responseTypes.SUCCESS,
 		onPaymentSetup,
+		activePaymentMethod,
 	] );
 
 	if ( fetchError ) {
@@ -239,7 +246,7 @@ const Label = ( props ) => {
 };
 
 const BlockGateway = {
-	name: 'payload',
+	name: PAYMENT_METHOD_NAME,
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,


### PR DESCRIPTION
# Description

`onPaymentSetup` observers registered via WooCommerce Blocks `eventRegistration` fire for every registered payment method during checkout processing — not only the selected one. The payload block was unconditionally calling `paymentFormRef.current.submit()` from inside its callback, which meant it attempted to tokenize a card whenever any other payment method was used to check out.

This guards the callback by comparing the new `activePaymentMethod` prop against a `PAYMENT_METHOD_NAME` constant (also used for `BlockGateway.name`) and returns early when Payload is not the selected method. `activePaymentMethod` is added to the `useEffect` dependency array so the closure captures the current value when the shopper switches methods.

Changes include:

- [x] Add `PAYMENT_METHOD_NAME` constant and use it for both registration and the active-method check
- [x] Early-return from the `onPaymentSetup` callback when Payload is not the active payment method
- [x] Add `activePaymentMethod` to the `useEffect` dependency array

## Type of change

- Bug fix (non-breaking change which fixes an issue)