### PR TITLE
PL-639: Fix saved card expiry date parsing

### DIFF
--- a/includes/class-wc-payload-gateway.php
+++ b/includes/class-wc-payload-gateway.php
@@ -695,6 +695,7 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 	 * @param  array    $payment_method Payment method data array.
 	 * @param  int|null $user_id        WordPress user ID (optional).
 	 * @return WC_Payment_Token_CC The created or existing payment token.
+	 * @throws Exception When the card expiry is not in the expected YYYY-MM-DD format.
 	 */
 	public function create_token( $payment_method, $user_id = null ) {
 		$token = new WC_Payment_Token_CC();
@@ -702,8 +703,14 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 		$token->set_gateway_id( $this->id );
 		$token->set_card_type( $payment_method['card']['card_brand'] );
 		$token->set_last4( substr( $payment_method['card']['card_number'], -4 ) );
-		// Payload returns the card expiry in YYYY-MM-DD format.
-		$expiry_parts = explode( '-', $payment_method['card']['expiry'] );
+		// Payload returns the card expiry in YYYY-MM-DD format. Guard against any
+		// other format so a malformed value fails loudly instead of silently
+		// saving a token with an incorrect expiry.
+		$expiry = isset( $payment_method['card']['expiry'] ) ? $payment_method['card']['expiry'] : '';
+		if ( ! is_string( $expiry ) || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $expiry ) ) {
+			throw new Exception( esc_html__( 'Unexpected card expiry format received from Payload.', 'payload' ) );
+		}
+		$expiry_parts = explode( '-', $expiry );
 		$token->set_expiry_year( $expiry_parts[0] );
 		$token->set_expiry_month( $expiry_parts[1] );
 

--- a/includes/class-wc-payload-gateway.php
+++ b/includes/class-wc-payload-gateway.php
@@ -702,8 +702,10 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 		$token->set_gateway_id( $this->id );
 		$token->set_card_type( $payment_method['card']['card_brand'] );
 		$token->set_last4( substr( $payment_method['card']['card_number'], -4 ) );
-		$token->set_expiry_month( substr( $payment_method['card']['expiry'], 0, 2 ) );
-		$token->set_expiry_year( substr( $payment_method['card']['expiry'], -4 ) );
+		// Payload returns the card expiry in YYYY-MM-DD format.
+		$expiry_parts = explode( '-', $payment_method['card']['expiry'] );
+		$token->set_expiry_year( $expiry_parts[0] );
+		$token->set_expiry_month( $expiry_parts[1] );
 
 		if ( $user_id ) {
 			// We create this flag just incase Admin is changing payment method for a user.

--- a/tests/Integration/Gateway/CompletePaymentFlows_Test.php
+++ b/tests/Integration/Gateway/CompletePaymentFlows_Test.php
@@ -43,7 +43,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$payment_method_id = 'pm_new123';
 		$card_brand        = 'visa';
 		$last4             = '1111';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 
 		// Mock HTTP responses for Payload API calls
 		CurlMocker::mockPaymentMethodGet( $payment_method_id, $card_brand, $last4, $expiry, null );
@@ -263,7 +263,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$payment_method_id = 'pm_new125';
 		$card_brand        = 'visa';
 		$last4             = '1111';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 
 		CurlMocker::mockPaymentMethodGet( $payment_method_id, $card_brand, $last4, $expiry, null );
 		CurlMocker::mockTransactionCreate(
@@ -344,7 +344,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$payment_method_id = 'pm_updated123';
 		$card_brand        = 'amex';
 		$last4             = '8888';
-		$expiry            = '06/2026';
+		$expiry            = '2026-06-01';
 
 		// Mock HTTP response for PaymentMethod::get()
 		CurlMocker::mockPaymentMethodGet( $payment_method_id, $card_brand, $last4, $expiry, null );
@@ -413,7 +413,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$card_brand        = 'visa';
 		$last4             = '1111';
 		$card_number       = '4111111111111111';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 		$description       = 'Visa ending in 1111';
 
 		// Mock HTTP responses for Payload API calls
@@ -515,7 +515,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$payment_method_id = 'pm_new123';
 		$card_brand        = 'visa';
 		$last4             = '1111';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 
 		// Mock HTTP responses for Payload API calls
 		CurlMocker::mockPaymentMethodGet( $payment_method_id, $card_brand, $last4, $expiry, null );
@@ -584,7 +584,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$token_id          = 111;
 		$card_brand        = 'mastercard';
 		$last4             = '5555';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 		$subscription_id   = 'sub_123';
 
 		$order = $this->create_mock_order( $order_id, $amount, $user_id );
@@ -679,7 +679,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$token_id          = 111;
 		$card_brand        = 'mastercard';
 		$last4             = '5555';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 		$subscription_id   = 'sub_123';
 
 		$order = $this->create_mock_order( $order_id, $amount, $user_id );
@@ -879,7 +879,7 @@ class Test_Integration_Payment_Flows extends IntegrationTestCase {
 		$payment_method_id = 'pm_123';
 		$card_brand        = 'visa';
 		$last4             = '1111';
-		$expiry            = '12/2025';
+		$expiry            = '2025-12-01';
 
 		// Mock HTTP responses for Payload API calls
 		CurlMocker::mockPaymentMethodGet( $payment_method_id, $card_brand, $last4, $expiry, null );

--- a/tests/Integration/Helpers/CurlMocker.php
+++ b/tests/Integration/Helpers/CurlMocker.php
@@ -214,7 +214,7 @@ class CurlMocker {
 					'card'        => array(
 						'card_brand'  => 'visa',
 						'card_number' => '4111111111111111',
-						'expiry'      => '12/2025',
+						'expiry'      => '2025-12-01',
 					),
 				),
 			)
@@ -276,7 +276,7 @@ class CurlMocker {
 					'card'        => array(
 						'card_brand'  => 'visa',
 						'card_number' => '4111111111111111',
-						'expiry'      => '12/2025',
+						'expiry'      => '2025-12-01',
 					),
 				),
 			),

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -228,7 +228,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 			'card' => array(
 				'card_brand'  => 'visa',
 				'card_number' => '4111111111111111',
-				'expiry'      => '12/' . date( 'Y', strtotime( '+1 year' ) ),
+				'expiry'      => '2031-12-31',
 			),
 		);
 
@@ -241,6 +241,26 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 
 		$this->assertInstanceOf( WC_Payment_Token_CC::class, $token );
 		$this->assertEquals( 'pm_test123', $token->get_token() );
+	}
+
+	public function test_create_token_parses_expiry_from_yyyy_mm_dd() {
+		$payment_method_data = array(
+			'id'   => 'pm_test123',
+			'card' => array(
+				'card_brand'  => 'visa',
+				'card_number' => '4111111111111111',
+				// Payload returns the card expiry in YYYY-MM-DD format.
+				'expiry'      => '2031-12-31',
+			),
+		);
+
+		Monkey\Functions\expect( 'get_current_user_id' )
+		->andReturn( 1 );
+
+		$token = $this->gateway->create_token( $payment_method_data );
+
+		$this->assertEquals( '12', $token->get_expiry_month() );
+		$this->assertEquals( '2031', $token->get_expiry_year() );
 	}
 
 	public function test_add_payment_method_success() {

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -189,7 +189,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 			'card' => array(
 				'card_brand'  => 'visa',
 				'card_number' => '4111111111111111',
-				'expiry'      => '12/2025',
+				'expiry'      => '2031-12-31',
 			),
 		);
 		$payment_mock->shouldReceive( 'update' )->andReturn( true );
@@ -273,7 +273,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 				'card' => array(
 					'card_brand'  => 'visa',
 					'card_number' => '4111111111111111',
-					'expiry'      => '12/' . date( 'Y', strtotime( '+1 year' ) ),
+					'expiry'      => '2031-12-31',
 				),
 			)
 		);
@@ -427,7 +427,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 			'card'        => array(
 				'card_brand'  => 'visa',
 				'card_number' => '4111111111111111',
-				'expiry'      => '12/2025',
+				'expiry'      => '2031-12-31',
 			),
 		);
 
@@ -471,7 +471,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 			'card'        => array(
 				'card_brand'  => 'visa',
 				'card_number' => '4111111111111111',
-				'expiry'      => '12/2025',
+				'expiry'      => '2031-12-31',
 			),
 		);
 
@@ -510,7 +510,7 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 			'card'        => array(
 				'card_brand'  => 'visa',
 				'card_number' => '4111111111111111',
-				'expiry'      => '12/2025',
+				'expiry'      => '2031-12-31',
 			),
 		);
 

--- a/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
+++ b/tests/Unit/Gateway/WC_Payload_Gateway_Test.php
@@ -263,6 +263,33 @@ class Test_WC_Payload_Gateway extends UnitTestCase {
 		$this->assertEquals( '2031', $token->get_expiry_year() );
 	}
 
+	/**
+	 * @dataProvider malformed_expiry_provider
+	 */
+	public function test_create_token_rejects_malformed_expiry( $expiry ) {
+		$payment_method_data = array(
+			'id'   => 'pm_test123',
+			'card' => array(
+				'card_brand'  => 'visa',
+				'card_number' => '4111111111111111',
+				'expiry'      => $expiry,
+			),
+		);
+
+		$this->expectException( Exception::class );
+
+		$this->gateway->create_token( $payment_method_data );
+	}
+
+	public function malformed_expiry_provider() {
+		return array(
+			'legacy MM/YYYY' => array( '12/2025' ), // the exact old format — guards against regressing the original bug.
+			'empty string'   => array( '' ),
+			'null'           => array( null ),
+			'no separators'  => array( '20311231' ),
+		);
+	}
+
 	public function test_add_payment_method_success() {
 		$_POST = array( 'payment_method_id' => 'pm_123' );
 

--- a/tests/mocks/payload-mocks.php
+++ b/tests/mocks/payload-mocks.php
@@ -28,7 +28,7 @@ namespace Payload {
 				'card' => array(
 					'card_brand'  => 'visa',
 					'card_number' => '4111111111111111',
-					'expiry'      => '12/2025',
+					'expiry'      => '2031-12-31',
 				),
 			);
 		}
@@ -59,7 +59,7 @@ namespace Payload {
 				'card'        => array(
 					'card_brand'  => 'visa',
 					'card_number' => '4111111111111111',
-					'expiry'      => '12/2025',
+					'expiry'      => '2031-12-31',
 				),
 			);
 


### PR DESCRIPTION
# Description

When saving a card from the Payment Methods page, the saved card always displayed its expiry date as `20/31` instead of the correct value.

The Payload API returns the card expiry in `YYYY-MM-DD` format, but `create_token()` parsed it positionally:

```php
$token->set_expiry_month( substr( $payment_method['card']['expiry'], 0, 2 ) );
$token->set_expiry_year( substr( $payment_method['card']['expiry'], -4 ) );
```

For `2031-12-31` this yields month `"20"` (the start of the year) and year `"2-31"`, which WooCommerce renders as `20/31`. The fix splits on `-` and maps the year and month from their correct positions.

Resolves PL-639.

Changes include:

- [x] Parse the Payload `YYYY-MM-DD` expiry format correctly in `create_token()`
- [x] Add a unit test (`test_create_token_parses_expiry_from_yyyy_mm_dd`) and update existing token test data to the real expiry format

## Type of change

- Bug fix (non-breaking change which fixes an issue)
